### PR TITLE
compiles now

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,3 @@
 ///<reference path="../typings/main.d.ts"/>
-
-import * as express from "express";
-
+var express = require("express");
 let app = express();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,6 @@
     "compilerOptions": {
         "target": "es6",
         "module": "commonjs"
-    }
+    },
+    "exclude": ["typings","node_modules"]
 }

--- a/typings.json
+++ b/typings.json
@@ -3,6 +3,8 @@
   "devDependencies": {},
   "ambientDependencies": {
     "express": "github:DefinitelyTyped/DefinitelyTyped/express/express.d.ts#dd4626a4e23ce8d6d175e0fe8244a99771c8c3f2",
-    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#1c56e368e17bb28ca57577250624ca5bd561aa81"
+    "mime": "github:DefinitelyTyped/DefinitelyTyped/mime/mime.d.ts#cb5206a8ac1c9a3ddfd126f5ecea6729b2361452",
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#1c56e368e17bb28ca57577250624ca5bd561aa81",
+    "serve-static": "github:DefinitelyTyped/DefinitelyTyped/serve-static/serve-static.d.ts#0fa4e9e61385646ea6a4cba2aef357353d2ce77f"
   }
 }

--- a/typings/browser.d.ts
+++ b/typings/browser.d.ts
@@ -1,2 +1,4 @@
-/// <reference path="browser/ambient/express/express.d.ts" />
-/// <reference path="browser/ambient/node/node.d.ts" />
+/// <reference path="browser\ambient\express\express.d.ts" />
+/// <reference path="browser\ambient\mime\mime.d.ts" />
+/// <reference path="browser\ambient\node\node.d.ts" />
+/// <reference path="browser\ambient\serve-static\serve-static.d.ts" />

--- a/typings/browser/ambient/mime/mime.d.ts
+++ b/typings/browser/ambient/mime/mime.d.ts
@@ -1,0 +1,22 @@
+// Compiled using typings@0.6.1
+// Source: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/cb5206a8ac1c9a3ddfd126f5ecea6729b2361452/mime/mime.d.ts
+// Type definitions for mime
+// Project: https://github.com/broofa/node-mime
+// Definitions by: Jeff Goddard <https://github.com/jedigo>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// Imported from: https://github.com/soywiz/typescript-node-definitions/mime.d.ts
+
+declare module "mime" {
+	export function lookup(path: string): string;
+	export function extension(mime: string): string;
+	export function load(filepath: string): void;
+	export function define(mimes: Object): void;
+
+	interface Charsets {
+		lookup(mime: string): string;
+	}
+
+	export var charsets: Charsets;
+	export var default_type: string;
+}

--- a/typings/browser/ambient/serve-static/serve-static.d.ts
+++ b/typings/browser/ambient/serve-static/serve-static.d.ts
@@ -1,0 +1,86 @@
+// Compiled using typings@0.6.1
+// Source: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/0fa4e9e61385646ea6a4cba2aef357353d2ce77f/serve-static/serve-static.d.ts
+// Type definitions for serve-static 1.7.1
+// Project: https://github.com/expressjs/serve-static
+// Definitions by: Uros Smolnik <https://github.com/urossmolnik/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/* =================== USAGE ===================
+
+    import * as serveStatic from "serve-static";
+    app.use(serveStatic("public/ftp", {"index": ["default.html", "default.htm"]}))
+
+ =============================================== */
+
+
+declare module "serve-static" {
+    import * as express from "express";
+
+    /**
+     * Create a new middleware function to serve files from within a given root directory.
+     * The file to serve will be determined by combining req.url with the provided root directory.
+     * When a file is not found, instead of sending a 404 response, this module will instead call next() to move on to the next middleware, allowing for stacking and fall-backs.
+     */
+    function serveStatic(root: string, options?: {
+        /**
+         * Set how "dotfiles" are treated when encountered. A dotfile is a file or directory that begins with a dot (".").
+         * Note this check is done on the path itself without checking if the path actually exists on the disk.
+         * If root is specified, only the dotfiles above the root are checked (i.e. the root itself can be within a dotfile when when set to "deny").
+         * The default value is 'ignore'.
+         * 'allow' No special treatment for dotfiles
+         * 'deny' Send a 403 for any request for a dotfile
+         * 'ignore' Pretend like the dotfile does not exist and call next()
+         */
+        dotfiles?: string;
+
+        /**
+         * Enable or disable etag generation, defaults to true.
+         */
+        etag?: boolean;
+
+        /**
+         * Set file extension fallbacks. When set, if a file is not found, the given extensions will be added to the file name and search for.
+         * The first that exists will be served. Example: ['html', 'htm'].
+         * The default value is false.
+         */
+        extensions?: string[];
+
+        /**
+         * By default this module will send "index.html" files in response to a request on a directory.
+         * To disable this set false or to supply a new index pass a string or an array in preferred order.
+         */
+        index?: boolean|string|string[];
+
+        /**
+         * Enable or disable Last-Modified header, defaults to true. Uses the file system's last modified value.
+         */
+        lastModified?: boolean;
+
+        /**
+         * Provide a max-age in milliseconds for http caching, defaults to 0. This can also be a string accepted by the ms module.
+         */
+        maxAge?: number|string;
+
+        /**
+         * Redirect to trailing "/" when the pathname is a dir. Defaults to true.
+         */
+        redirect?: boolean;
+
+        /**
+         * Function to set custom headers on response. Alterations to the headers need to occur synchronously.
+         * The function is called as fn(res, path, stat), where the arguments are:
+         * res the response object
+         * path the file path that is being sent
+         * stat the stat object of the file that is being sent
+         */
+        setHeaders?: (res: express.Response, path: string, stat: any) => any;
+    }): express.Handler;
+
+    import * as m from "mime";
+
+    module serveStatic {
+        var mime: typeof m;
+    }
+
+    export = serveStatic;
+}

--- a/typings/main.d.ts
+++ b/typings/main.d.ts
@@ -1,2 +1,4 @@
-/// <reference path="main/ambient/express/express.d.ts" />
-/// <reference path="main/ambient/node/node.d.ts" />
+/// <reference path="main\ambient\express\express.d.ts" />
+/// <reference path="main\ambient\mime\mime.d.ts" />
+/// <reference path="main\ambient\node\node.d.ts" />
+/// <reference path="main\ambient\serve-static\serve-static.d.ts" />

--- a/typings/main/ambient/mime/mime.d.ts
+++ b/typings/main/ambient/mime/mime.d.ts
@@ -1,0 +1,22 @@
+// Compiled using typings@0.6.1
+// Source: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/cb5206a8ac1c9a3ddfd126f5ecea6729b2361452/mime/mime.d.ts
+// Type definitions for mime
+// Project: https://github.com/broofa/node-mime
+// Definitions by: Jeff Goddard <https://github.com/jedigo>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// Imported from: https://github.com/soywiz/typescript-node-definitions/mime.d.ts
+
+declare module "mime" {
+	export function lookup(path: string): string;
+	export function extension(mime: string): string;
+	export function load(filepath: string): void;
+	export function define(mimes: Object): void;
+
+	interface Charsets {
+		lookup(mime: string): string;
+	}
+
+	export var charsets: Charsets;
+	export var default_type: string;
+}

--- a/typings/main/ambient/serve-static/serve-static.d.ts
+++ b/typings/main/ambient/serve-static/serve-static.d.ts
@@ -1,0 +1,86 @@
+// Compiled using typings@0.6.1
+// Source: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/0fa4e9e61385646ea6a4cba2aef357353d2ce77f/serve-static/serve-static.d.ts
+// Type definitions for serve-static 1.7.1
+// Project: https://github.com/expressjs/serve-static
+// Definitions by: Uros Smolnik <https://github.com/urossmolnik/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/* =================== USAGE ===================
+
+    import * as serveStatic from "serve-static";
+    app.use(serveStatic("public/ftp", {"index": ["default.html", "default.htm"]}))
+
+ =============================================== */
+
+
+declare module "serve-static" {
+    import * as express from "express";
+
+    /**
+     * Create a new middleware function to serve files from within a given root directory.
+     * The file to serve will be determined by combining req.url with the provided root directory.
+     * When a file is not found, instead of sending a 404 response, this module will instead call next() to move on to the next middleware, allowing for stacking and fall-backs.
+     */
+    function serveStatic(root: string, options?: {
+        /**
+         * Set how "dotfiles" are treated when encountered. A dotfile is a file or directory that begins with a dot (".").
+         * Note this check is done on the path itself without checking if the path actually exists on the disk.
+         * If root is specified, only the dotfiles above the root are checked (i.e. the root itself can be within a dotfile when when set to "deny").
+         * The default value is 'ignore'.
+         * 'allow' No special treatment for dotfiles
+         * 'deny' Send a 403 for any request for a dotfile
+         * 'ignore' Pretend like the dotfile does not exist and call next()
+         */
+        dotfiles?: string;
+
+        /**
+         * Enable or disable etag generation, defaults to true.
+         */
+        etag?: boolean;
+
+        /**
+         * Set file extension fallbacks. When set, if a file is not found, the given extensions will be added to the file name and search for.
+         * The first that exists will be served. Example: ['html', 'htm'].
+         * The default value is false.
+         */
+        extensions?: string[];
+
+        /**
+         * By default this module will send "index.html" files in response to a request on a directory.
+         * To disable this set false or to supply a new index pass a string or an array in preferred order.
+         */
+        index?: boolean|string|string[];
+
+        /**
+         * Enable or disable Last-Modified header, defaults to true. Uses the file system's last modified value.
+         */
+        lastModified?: boolean;
+
+        /**
+         * Provide a max-age in milliseconds for http caching, defaults to 0. This can also be a string accepted by the ms module.
+         */
+        maxAge?: number|string;
+
+        /**
+         * Redirect to trailing "/" when the pathname is a dir. Defaults to true.
+         */
+        redirect?: boolean;
+
+        /**
+         * Function to set custom headers on response. Alterations to the headers need to occur synchronously.
+         * The function is called as fn(res, path, stat), where the arguments are:
+         * res the response object
+         * path the file path that is being sent
+         * stat the stat object of the file that is being sent
+         */
+        setHeaders?: (res: express.Response, path: string, stat: any) => any;
+    }): express.Handler;
+
+    import * as m from "mime";
+
+    module serveStatic {
+        var mime: typeof m;
+    }
+
+    export = serveStatic;
+}


### PR DESCRIPTION
* You probably should exclude `typings` and `node_modules` otherwise the compile will contain duplicate identifiers (typings) / will be slow (node_modules)

* typings install `serve-static` (needed for `express`) and `mime` (needed for `serve-static`). 